### PR TITLE
FIX: Single Device Connected Stuck on "Waiting for device..."

### DIFF
--- a/sadb.py
+++ b/sadb.py
@@ -45,6 +45,14 @@ def select_device(devices, allow_all=False):
             print("Invalid choice")
 
 
+def call_function_on_devices(selected_devices, func, *args):
+    if isinstance(selected_devices, list):
+        for device in selected_devices:
+            func(device, *args)
+    else:
+        func(selected_devices, *args)
+
+
 def stop(device, package_name):
     cmd = ["adb", "-s", device, "shell", "am", "force-stop", package_name]
     subprocess.run(cmd)
@@ -230,51 +238,36 @@ def main():
             selected_devices = select_device(devices, allow_all=True)
             if selected_devices is None:
                 return
-            if isinstance(selected_devices, list):
-                for device in selected_devices:
-                    uninstall(device, args.package_name)
-            for device in selected_devices:
-                stop(device, args.package_name)
+            call_function_on_devices(
+                selected_devices, stop, args.package_name)
 
         elif args.command == "start":
             selected_devices = select_device(devices, allow_all=True)
             if selected_devices is None:
                 return
-            if isinstance(selected_devices, list):
-                for device in selected_devices:
-                    uninstall(device, args.package_name)
-            for device in selected_devices:
-                start(device, args.package_name)
+            call_function_on_devices(
+                selected_devices, start, args.package_name)
 
         elif args.command == "clear":
             selected_devices = select_device(devices, allow_all=True)
             if selected_devices is None:
                 return
-            if isinstance(selected_devices, list):
-                for device in selected_devices:
-                    uninstall(device, args.package_name)
-            for device in selected_devices:
-                clear(device, args.package_name)
+            call_function_on_devices(
+                selected_devices, clear, args.package_name)
 
         elif args.command == "install":
             selected_devices = select_device(devices, allow_all=True)
             if selected_devices is None:
                 return
-            if isinstance(selected_devices, list):
-                for device in selected_devices:
-                    uninstall(device, args.package_name)
-            for device in selected_devices:
-                install(device, args.apk)
+            call_function_on_devices(
+                selected_devices, install, args.apk)
 
         elif args.command == "uninstall":
             selected_devices = select_device(devices, allow_all=True)
             if selected_devices is None:
                 return
-            if isinstance(selected_devices, list):
-                for device in selected_devices:
-                    uninstall(device, args.package_name)
-            else:
-                uninstall(selected_devices, args.package_name)
+            call_function_on_devices(
+                selected_devices, uninstall, args.package_name)
 
         elif args.command == "scrcpy":
             device = select_device(devices)

--- a/sadb.py
+++ b/sadb.py
@@ -1,8 +1,7 @@
 # Created by:   Seamus Sloan
-# Last Edited:  June 15, 2023
+# Last Edited:  July 6, 2023
 
 import argparse
-import os
 import sys
 import subprocess
 import time

--- a/sadb.py
+++ b/sadb.py
@@ -16,11 +16,16 @@ def get_devices():
 
 
 def select_device(devices, allow_all=False):
+    # If there are no devices found...
     if len(devices) == 0:
         print("No devices found")
         return None
+
+    # If there is only one device found...
     if len(devices) == 1:
         return devices[0]
+
+    # If there are multiple devices found...
     print("Select a device:")
     for i, device in enumerate(devices):
         print(f"{i + 1}. {device}")
@@ -225,6 +230,9 @@ def main():
             selected_devices = select_device(devices, allow_all=True)
             if selected_devices is None:
                 return
+            if isinstance(selected_devices, list):
+                for device in selected_devices:
+                    uninstall(device, args.package_name)
             for device in selected_devices:
                 stop(device, args.package_name)
 
@@ -232,6 +240,9 @@ def main():
             selected_devices = select_device(devices, allow_all=True)
             if selected_devices is None:
                 return
+            if isinstance(selected_devices, list):
+                for device in selected_devices:
+                    uninstall(device, args.package_name)
             for device in selected_devices:
                 start(device, args.package_name)
 
@@ -239,6 +250,9 @@ def main():
             selected_devices = select_device(devices, allow_all=True)
             if selected_devices is None:
                 return
+            if isinstance(selected_devices, list):
+                for device in selected_devices:
+                    uninstall(device, args.package_name)
             for device in selected_devices:
                 clear(device, args.package_name)
 
@@ -246,6 +260,9 @@ def main():
             selected_devices = select_device(devices, allow_all=True)
             if selected_devices is None:
                 return
+            if isinstance(selected_devices, list):
+                for device in selected_devices:
+                    uninstall(device, args.package_name)
             for device in selected_devices:
                 install(device, args.apk)
 
@@ -253,8 +270,11 @@ def main():
             selected_devices = select_device(devices, allow_all=True)
             if selected_devices is None:
                 return
-            for device in selected_devices:
-                uninstall(device, args.package_name)
+            if isinstance(selected_devices, list):
+                for device in selected_devices:
+                    uninstall(device, args.package_name)
+            else:
+                uninstall(selected_devices, args.package_name)
 
         elif args.command == "scrcpy":
             device = select_device(devices)


### PR DESCRIPTION
## Issue Description
When a user would only have one device connected, the functions would think that the `device` was a list which would cause commands to come out like `adb -s 4 install com.my.app` instead of `adb -s 4LFCL5R115GFNV install com.my.app`. This would occur on all functions where `allow_all = True`.

## Resolution
- Perform a check before sending to the appropriate function to ensure that we're only sending one device to the function and not a list _**ever**_. 

## What else is new?
- Removed an unused import
- Added a helper function `call_function_on_devices` to make it easier to understand the "send single device to command" functionality
- Added some comments on some spaghetti code
