### PR TITLE
FIX: Record Broken on Some Devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ sadb scrcpy
     - Start scrcpy on a device
 sadb ip 
     - Get the selected device's IP address
-sadb screenshot myScreenshot.png 
+sadb screenshot -f myScreenshot.png 
     - Take a screenshot of a device
-sadb record myVideo.mp4 
+sadb record -f myVideo.mp4 
     - Record the screen of a device (Press CTRL-C to stop recording)
 sadb wifi 
     - Connect to a device via WiFi

--- a/sadb.py
+++ b/sadb.py
@@ -16,7 +16,7 @@ def split_get_devices(result):
 
 
 def get_devices():
-    result = subprocess.run(["adb", "devices"], capture_output=True, text=True)
+    result = subprocess.run(["adb", "devices"], capture_output=True, text=True, check=False)
     return split_get_devices(result.stdout)
 
 
@@ -114,7 +114,7 @@ def screenshot(device, filename):
 def record(device, filename):
     if not filename:
         filename = "video.mp4"
-    remote_path = "/sdcard/screenrecord.mp4"
+    remote_path = "/data/local/tmp/screenrecord.mp4"
 
     cmd = ["adb", "-s", device, "shell", f"screenrecord {remote_path}"]
     proc = subprocess.Popen(cmd)
@@ -135,6 +135,7 @@ def record(device, filename):
 
     cmd = ["adb", "-s", device, "shell", f"rm {remote_path}"]
     subprocess.run(cmd)
+
 
 
 def wifi(device):
@@ -295,6 +296,7 @@ def main():
             screenshot(device, args.filename)
 
         elif args.command == "record":
+            print(args.filename)
             device = select_device(devices)
             if device is None:
                 return

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -92,7 +92,7 @@ def test_screenshot_custom_name():
 
 def test_record_custom_name():
     filename = "custom.mp4"
-    remote_path = "/sdcard/screenrecord.mp4"
+    remote_path = "/data/local/tmp/screenrecord.mp4"
 
     mock_proc = MagicMock()
     with patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
@@ -109,7 +109,7 @@ def test_record_custom_name():
 
 def test_record_default_name():
     filename = "video.mp4"
-    remote_path = "/sdcard/screenrecord.mp4"
+    remote_path = "/data/local/tmp/screenrecord.mp4"
 
     mock_proc = MagicMock()
     with patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \


### PR DESCRIPTION
## What's New?
Some devices did not have access to the `/sdcard/` directory or that directory did not exist. This meant that placing and pulling the video file would result in a blank file that would not be playable.

Instead of `/sdcard/your_video_here.mp4`, we're now using `/data/local/tmp/your_video_here.mp4`.

Tests were fixed & fix was validated on a DJI RC Plus (Android 10), Pixel 4 XL (Android 14), and S20 (Android 12).